### PR TITLE
Refine DUT build: make DUT build only for changed modules in PR

### DIFF
--- a/.github/workflows/self-hosted-ci-pr-checker.yaml
+++ b/.github/workflows/self-hosted-ci-pr-checker.yaml
@@ -57,5 +57,5 @@ jobs:
       if: steps.analyze_changes.outputs.test_duts != ''
       run: |
         make update_python_deps
-        make test target="${{ steps.analyze_changes.outputs.test_duts }}"
+        make test target="${{ steps.analyze_changes.outputs.test_duts }}" DUTS="'${{ steps.analyze_changes.outputs.test_duts }}'"
       shell: bash

--- a/.github/workflows/self-hosted-ci-pr-checker.yaml
+++ b/.github/workflows/self-hosted-ci-pr-checker.yaml
@@ -44,7 +44,7 @@ jobs:
       run: |
         changed_dirs=$(awk -F'/' '/^ut_/ {print $1"/"$2}' changed_files.txt | sort | uniq)
         test_duts=$(echo "$changed_dirs" | tr '\n' ' ')
-        if [ -z "$test_duts" ]; then
+        if [[ -z "$test_duts" || "$test_duts" =~ ^[[:space:]]+$ ]]; then
           echo "No changes in ut_* directories. Skipping run tests."
           exit 0
         else

--- a/.github/workflows/self-hosted-ci-pr-checker.yaml
+++ b/.github/workflows/self-hosted-ci-pr-checker.yaml
@@ -21,11 +21,6 @@ jobs:
       with:
         timezoneLinux: "Asia/Shanghai"
 
-    - name: Update picker
-      run: |
-        bash /home/update_picker.sh
-      shell: bash
-
     - name: Checkout code
       uses: actions/checkout@v4
       with:
@@ -51,6 +46,12 @@ jobs:
           echo "Changed directories: $test_duts"
           echo "::set-output name=test_duts::$test_duts"
         fi
+      shell: bash
+
+    - name: Update picker
+      if: steps.analyze_changes.outputs.test_duts != ''
+      run: |
+        bash /home/update_picker.sh
       shell: bash
 
     - name: Run tests in the changed ut_* directories


### PR DESCRIPTION
# Description

Pass the DUTS parameter to the build DUT through `.github/workflows/self-hosted-ci-pr-checker.yaml` to make the CI only compile the required DUTs that need to run.

## Type of change

- [X] New feature (non-breaking change which adds functionality)


# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] My changes generate no new warnings
- [X] New and existing unit tests pass locally with my changes
