### PR TITLE
add -tname option to the picker command in ftq_top script

### DIFF
--- a/scripts/build_ut_frontend_ftq_pc_mem.py
+++ b/scripts/build_ut_frontend_ftq_pc_mem.py
@@ -4,7 +4,7 @@ from comm import warning, info
 def build(cfg):
     # import base modules
     from toffee_test.markers import match_version
-    from comm import is_all_file_exist, get_rtl_dir, exe_cmd, get_root_dir
+    from comm import is_all_file_exist, get_rtl_dir, exe_cmd, get_root_dir, get_all_rtl_files
     # check version
     if not match_version(cfg.rtl.version, "openxiangshan-kmh-*"):
         warning("frontend_ftq_redirect_mem: %s" % f"Unsupported RTL version {cfg.rtl.version}")
@@ -12,24 +12,15 @@ def build(cfg):
     # check files
     module_name = "FtqPcMem"
     file_name ="FtqPcMemWrapper.sv"
-    dp_file_names = [
-    "SyncDataModuleTemplate_FtqPC_64entry.sv", 
-    "DataModule_FtqPC_16entry.sv"
-    ]
-    dp_fpaths = [f"rtl/rtl/{dp_file_name}" for dp_file_name in dp_file_names]
-    dp_fpaths_after_get_root = [get_root_dir(dp_fpath) for dp_fpath in dp_fpaths]
-    fpath = f"rtl/{file_name}"
-    all_fpaths = dp_fpaths + [fpath]
-    ## internal signals is now not determined
+    rtl_files = get_all_rtl_files("FtqPcMemWrapper", cfg=cfg)
     internal_signals_path=""
-    f = is_all_file_exist(all_fpaths, get_rtl_dir(cfg=cfg))
-    #assert f is True, f"File {f} not found"
+
     # build
     # export SyncDataModuleTemplate__64entry.sv
     if not os.path.exists(get_root_dir(f"dut/{module_name}")):
         info(f"Exporting {file_name}.sv")
-        s,out,err = exe_cmd(f'picker export {get_rtl_dir(f"{fpath}",cfg = cfg)} --tname {module_name}\
-                            --lang python --tdir {get_root_dir("dut")}/ -w {module_name}.fst -c --fs ' + ' '.join(dp_fpaths_after_get_root))
+        s,out,err = exe_cmd(f'picker export {rtl_files[0]} --tname {module_name}\
+                            --lang python --tdir {get_root_dir("dut")}/ -w {module_name}.fst -c --fs ' + ' '.join(rtl_files))
         assert s, f"Failed to export {file_name}.sv: %s\n%s" % (out, err)
 
     return True

--- a/scripts/build_ut_frontend_ftq_pd_mem.py
+++ b/scripts/build_ut_frontend_ftq_pd_mem.py
@@ -4,7 +4,7 @@ from comm import warning, info
 def build(cfg):
     # import base modules
     from toffee_test.markers import match_version
-    from comm import is_all_file_exist, get_rtl_dir, exe_cmd, get_root_dir
+    from comm import is_all_file_exist, get_rtl_dir, exe_cmd, get_root_dir, get_all_rtl_files
     # check version
     if not match_version(cfg.rtl.version, "openxiangshan-kmh-*"):
         warning("frontend_ftq_pd_mem: %s" % f"Unsupported RTL version {cfg.rtl.version}")
@@ -12,23 +12,15 @@ def build(cfg):
     # check files
     module_name = "FtqPdMem"
     file_name ="SyncDataModuleTemplate__64entry_2.sv"
-    dp_file_names = [
-    "DataModule__16entry_8.sv", 
-    ]
-    dp_fpaths = [f"rtl/rtl/{dp_file_name}" for dp_file_name in dp_file_names]
-    dp_fpaths_after_get_root = [get_root_dir(dp_fpath) for dp_fpath in dp_fpaths]
-    fpath = f"rtl/{file_name}"
-    all_fpaths = dp_fpaths + [fpath]
-    ## internal signals is now not determined
+    rtl_files = get_all_rtl_files("SyncDataModuleTemplate__64entry_2", cfg=cfg)
     internal_signals_path=""
-    f = is_all_file_exist(all_fpaths, get_rtl_dir(cfg=cfg))
-    #assert f is True, f"File {f} not found"    ##some problem here
+
     # build
     # export SyncDataModuleTemplate__64_1entry.sv
     if not os.path.exists(get_root_dir(f"dut/{module_name}")):
         info(f"Exporting {file_name}.sv")
-        s,out,err = exe_cmd(f'picker export {get_rtl_dir(f"{fpath}",cfg = cfg)} --tname {module_name}\
-                            --lang python --tdir {get_root_dir("dut")}/ -w {module_name}.fst -c --fs ' + ' '.join(dp_fpaths_after_get_root))
+        s,out,err = exe_cmd(f'picker export {rtl_files[0]} --tname {module_name}\
+                            --lang python --tdir {get_root_dir("dut")}/ -w {module_name}.fst -c --fs ' + ' '.join(rtl_files))
         assert s, f"Failed to export {file_name}.sv: %s\n%s" % (out, err)
 
     return True

--- a/scripts/build_ut_frontend_ftq_redirect_mem.py
+++ b/scripts/build_ut_frontend_ftq_redirect_mem.py
@@ -4,7 +4,7 @@ from comm import warning, info
 def build(cfg):
     # import base modules
     from toffee_test.markers import match_version
-    from comm import is_all_file_exist, get_rtl_dir, exe_cmd, get_root_dir
+    from comm import is_all_file_exist, get_rtl_dir, exe_cmd, get_root_dir, get_all_rtl_files
     # check version
     if not match_version(cfg.rtl.version, "openxiangshan-kmh-*"):
         warning("frontend_ftq_redirect_mem: %s" % f"Unsupported RTL version {cfg.rtl.version}")
@@ -12,23 +12,15 @@ def build(cfg):
     # check files
     module_name = "FtqRedirectMem"
     file_name ="SyncDataModuleTemplate__64entry.sv"
-    dp_file_names = [
-    "DataModule__16entry.sv", 
-    ]
-    dp_fpaths = [f"rtl/rtl/{dp_file_name}" for dp_file_name in dp_file_names]
-    dp_fpaths_after_get_root = [get_root_dir(dp_fpath) for dp_fpath in dp_fpaths]
-    fpath = f"rtl/{file_name}"
-    all_fpaths = dp_fpaths + [fpath]
-    ## internal signals is now not determined
+    rtl_files = get_all_rtl_files("SyncDataModuleTemplate__64entry", cfg=cfg)
     internal_signals_path=""
-    f = is_all_file_exist(all_fpaths, get_rtl_dir(cfg=cfg))
-    #assert f is True, f"File {f} not found"
+
     # build
     # export SyncDataModuleTemplate__64entry.sv
     if not os.path.exists(get_root_dir(f"dut/{module_name}")):
         info(f"Exporting {file_name}.sv")
-        s,out,err = exe_cmd(f'picker export {get_rtl_dir(f"{fpath}",cfg = cfg)} --tname {module_name}\
-                            --lang python --tdir {get_root_dir("dut")}/ -w {module_name}.fst -c --fs ' + ' '.join(dp_fpaths_after_get_root))
+        s,out,err = exe_cmd(f'picker export {rtl_files[0]} --tname {module_name}\
+                            --lang python --tdir {get_root_dir("dut")}/ -w {module_name}.fst -c --fs ' + ' '.join(rtl_files))
         assert s, f"Failed to export {file_name}.sv: %s\n%s" % (out, err)
 
     return True

--- a/scripts/build_ut_frontend_ftq_top.py
+++ b/scripts/build_ut_frontend_ftq_top.py
@@ -4,7 +4,7 @@ from comm import warning, info
 def build(cfg):
     # import base modules
     from toffee_test.markers import match_version
-    from comm import is_all_file_exist, get_rtl_dir, exe_cmd, get_root_dir
+    from comm import is_all_file_exist, get_rtl_dir, exe_cmd, get_root_dir, get_all_rtl_files
     # check version
     if not match_version(cfg.rtl.version, "openxiangshan-kmh-*"):
         warning("frontend_ftq_top: %s" % f"Unsupported RTL version {cfg.rtl.version}")
@@ -12,44 +12,15 @@ def build(cfg):
     # check files 1
     module_name = "FtqTop"
     file_name ="Ftq.sv"
-    dp_file_names = [
-    "SyncDataModuleTemplate__64entry.sv", 
-    "SyncDataModuleTemplate__64entry_1.sv", 
-    "SyncDataModuleTemplate__64entry_2.sv", 
-    "SyncDataModuleTemplate__64entry_3.sv", 
-    "DataModule__16entry.sv", 
-    "DataModule__16entry_4.sv", 
-    "DataModule__16entry_8.sv", 
-    "DataModule__16entry_12.sv", 
-    "FTBEntryGen.sv", 
-    "FtqNRSRAM.sv", 
-    "FtqPcMemWrapper.sv", 
-    "SRAMTemplate_65.sv", 
-    "SyncDataModuleTemplate_FtqPC_64entry.sv", 
-    "DataModule_FtqPC_16entry.sv", 
-    "array_0_0.sv", 
-    "array_0_0_ext.v",
-    "ClockGate.sv",
-    "MbistClockGateCell.sv",
-    "sram_array_2p64x576m192s1h0l1b_ftq.sv",
-    "array_8.sv",
-    "array_8_ext.v",
-    "MbistPipeFtq.sv"
-    ]
-    dp_fpaths = [f"rtl/rtl/{dp_file_name}" for dp_file_name in dp_file_names]
-    dp_fpaths_after_get_root = [get_root_dir(dp_fpath) for dp_fpath in dp_fpaths]
-    fpath = f"rtl/{file_name}"
-    all_fpaths = dp_fpaths + [fpath]
-    ## internal signals is now not determined
+    rtl_files = get_all_rtl_files("Ftq", cfg=cfg)
     internal_signals_path=""
-    f = is_all_file_exist(all_fpaths, get_rtl_dir(cfg=cfg))
-    #assert f is True, f"File {f} not found"
+
     # build
     # export ftq.sv
     if not os.path.exists(get_root_dir(f"dut/{module_name}")):
         info("Exporting Ftq.sv")
-        s,out,err = exe_cmd(f'picker export --cp_lib false {get_rtl_dir(f"{fpath}",cfg = cfg)} \
-                            --lang python --tdir {get_root_dir("dut")}/ -w {module_name}.fst -c --fs ' + ' '.join(dp_fpaths_after_get_root))
+        s,out,err = exe_cmd(f'picker export --cp_lib false {rtl_files[0]} --tname {module_name}\
+                            --lang python --tdir {get_root_dir("dut")}/ -w {module_name}.fst -c --fs ' + ' '.join(rtl_files))
         assert s, f"Failed to export Ftq.sv: %s\n%s" % (out, err)
 
     return True


### PR DESCRIPTION
# Description

add -tname option to the picker command in ftq_top script to allow repeated directory creation, (also, I use helper functions to make the code cleaner)

I found that during multiple make all attempts, compilation sometimes failed because the target build directory for FTQ Top already existed. Manually deleting the directory and recompiling would resolve the issue. However, to make it more convenient for developers who may not be familiar with such operations, I added a -tname option to the build script to avoid this problem.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

 run the following command in the root_dir : make all

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have added the appropriate labels
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
